### PR TITLE
Allow local hostnames in URLs (e.g. "http://my-host/foo").

### DIFF
--- a/url/src/main/java/com/mastfrog/url/Host.java
+++ b/url/src/main/java/com/mastfrog/url/Host.java
@@ -214,7 +214,7 @@ public final class Host implements URLComponent, Validating, Iterable<Label> {
             return true;
         }
         boolean ip = isIpAddress();
-        boolean result = ip || (getTopLevelDomain() != null && getDomain() != null);
+        boolean result = ip || isLocalHostname() || isInternetHostname();
         if (result) {
             boolean someNumeric = false;
             boolean allNumeric = true;
@@ -243,6 +243,22 @@ public final class Host implements URLComponent, Validating, Iterable<Label> {
         return result;
     }
 
+    private boolean isDomain() {
+        return getDomain() != null;
+    }
+    
+    private boolean isLocalHostname() {
+        return (labels.length == 1 && !isDomain() && !isTopLevelDomain());
+    }
+    
+    private boolean isInternetHostname() {
+        return (isDomain() && isTopLevelDomain());
+    }
+    
+    private boolean isTopLevelDomain() {
+        return getTopLevelDomain() != null;
+    }
+
     @Override
     public Problems getProblems() {
         if (isLocalhost() && !"".equals(toString())) {
@@ -256,12 +272,11 @@ public final class Host implements URLComponent, Validating, Iterable<Label> {
         if (isIpV6Address()) {
             return problems;
         }
-        boolean isIp = isIpAddress();
         if (problems.allProblems().isEmpty()) {
-            if (!isIp && getTopLevelDomain() == null) {
+            if (!isIpAddress() && !isLocalHostname() && getTopLevelDomain() == null) {
                 problems.append(LocalizationSupport.getMessage(Host.class, "TopLevelDomainMissing"));
             }
-            if (!isIp && getDomain() == null) {
+            if (!isIpAddress() && !isLocalHostname() && getDomain() == null) {
                 problems.append(LocalizationSupport.getMessage(Host.class, "DomainMissing"));
             }
             if (length() > 255) {

--- a/url/src/test/java/com/mastfrog/url/HostIpV6Test.java
+++ b/url/src/test/java/com/mastfrog/url/HostIpV6Test.java
@@ -163,6 +163,7 @@ public class HostIpV6Test {
         assertTrue(new Label("c").isValid());
         assertTrue(new Label("1").isValid());
         assertTrue(Host.parse("food.com").isValid());
+        assertTrue(Host.parse("my-host").isValid());
     }
 
     @Test

--- a/url/src/test/java/com/mastfrog/url/URLTest.java
+++ b/url/src/test/java/com/mastfrog/url/URLTest.java
@@ -574,8 +574,8 @@ public class URLTest {
 
     @Test
     public void validity() {
-        assertInvalid("http:///a/b/c");
-        assertInvalid("http://x/a/b/c");
+        assertInvalid("http:///127/b/c");
+        assertInvalid("http://127/a/b/c");
         assertInvalid("http://127.z.b.32/a/b/c");
         assertInvalid("http://127.z.b.32/a/b/c");
 
@@ -586,7 +586,7 @@ public class URLTest {
         lng.append(".com");
         assertInvalid("http://" + lng + "/x.txt");
         assertInvalid("http://");
-        assertInvalid("http://foo");
+        assertValid("http://my-host");
         assertInvalid("a");
         assertInvalid("a:b");
         assertInvalid("a:b:c");


### PR DESCRIPTION
The URL of the repository of my company ("http://company-nexus/somerepo") contains a local hostname ("company-nexus"). The changes of this pull request were necessary to allow me to use "tiny-maven-proxy" (which uses acteur).